### PR TITLE
Return the `returnValue` of the actual function call

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function makePromisable (parent, prop) {
         returnValue = Reflect.apply(target, parent, argumentsList)
       })
       // Return the returnValue through valueOf
-      promise.valueOf = _ => returnValue
+      promise.valueOf = () => returnValue
       return promise
     }
   })

--- a/index.js
+++ b/index.js
@@ -29,13 +29,17 @@ function makePromisable (parent, prop) {
     // this is cool to make promiseable event emitters
     //  and many other native node methods
     apply: (target, thisArg, argumentsList) => {
-      return new Promise((resolve, reject) => {
+      let returnValue
+      const promise = new Promise((resolve, reject) => {
         // guessing the timer functions from the type of arguments passed to the method
         const isTimer = !argumentsList.length || typeof argumentsList[0] === 'number'
         // assuming the callback will be always the second argument
         argumentsList.splice(isTimer ? 0 : 1, 0, resolve)
-        Reflect.apply(target, parent, argumentsList)
+        returnValue = Reflect.apply(target, parent, argumentsList)
       })
+      // Return the returnValue through valueOf
+      promise.valueOf = _ => returnValue
+      return promise
     }
   })
 }


### PR DESCRIPTION
This is useful for cancelling timers and for other async functions which provide a return value.

Example:

```
const s = myWin.setTimeout(3000)
s.then(_ => console.log('time over'))
…
clearTimeout(s)
```

It can either be extracted explicitly:

```
const s = myWin.setTimeout(3000)
const retunValue = s.valueOf()
```

or implicitly through coercion:

```
const s = myWin.setTimeout(3000)
Number(s) // 1234
+s // 1234
'' + s // "1234"
Boolean(s) // true
!!s // true
…
```
